### PR TITLE
Optimize rendering of folder listings

### DIFF
--- a/bulgur-cloud-frontend/src/Dashboard.tsx
+++ b/bulgur-cloud-frontend/src/Dashboard.tsx
@@ -20,6 +20,9 @@ import { useEnsureAuthInitialized, useLogout } from "./client/auth";
 import { FullPageLoading } from "./Loading";
 import { Banner } from "./components/Banner";
 import { UploadProgress } from "./UploadProgress";
+import { RenameModal } from "./storage/RenameModal";
+import { CreateFolderModal } from "./Upload";
+import { DeleteModal } from "./storage/DeleteModal";
 
 function StorageItem(params: DashboardParams) {
   if (params.route.params.isFile) {
@@ -115,6 +118,9 @@ export function Dashboard(params: DashboardParams) {
         </VStack>
       </Center>
       <UploadProgress />
+      <RenameModal />
+      <CreateFolderModal />
+      <DeleteModal />
     </Box>
   );
 }

--- a/bulgur-cloud-frontend/src/components/FilenameModal.tsx
+++ b/bulgur-cloud-frontend/src/components/FilenameModal.tsx
@@ -47,40 +47,15 @@ export type FilenameModalProps<
   cancel?: Cancel;
 };
 
-/** Returns the filename modal element, and a hook that can be used to open the
- * element.
- */
-export function useFilenameModal<
-  Actions extends FilenameModalActionMap,
-  Primary extends keyof Actions,
-  Cancel extends keyof Actions,
->(
-  props: FilenameModalProps<Actions, Primary, Cancel>,
-): [() => void, JSX.Element] {
-  const [isOpen, setOpen] = useState(false);
-  return [
-    () => {
-      setOpen(true);
-    },
-    <FilenameModal
-      // Not actually necessary but trips up the linter
-      key={props.title}
-      {...props}
-      openState={[isOpen, setOpen]}
-    />,
-  ];
-}
-
-function FilenameModal<
+export function FilenameModal<
   Actions extends FilenameModalActionMap,
   Primary extends keyof Actions,
   Cancel extends keyof Actions,
 >(
   props: FilenameModalProps<Actions, Primary, Cancel> & {
-    openState: [boolean, (set: boolean) => void];
+    onDismiss: () => void;
   },
 ) {
-  const [isOpen, setOpen] = props.openState;
   const [newName, setNewName] = useState(props.initialValue ?? "");
 
   const safety = isSafeFilename(newName);
@@ -117,17 +92,17 @@ function FilenameModal<
     } else {
       console.log("submit");
       if (primary.action) primary.action(newName);
-      setOpen(false);
+      props.onDismiss();
     }
   };
-  const onDismiss = () => {
+  const onClose = () => {
     console.log("cancel");
     if (cancel.action) cancel.action(newName);
-    setOpen(false);
+    props.onDismiss();
   };
 
   return (
-    <Modal onClose={onDismiss} avoidKeyboard={true} isOpen={isOpen}>
+    <Modal onClose={onClose} avoidKeyboard={true} isOpen={true}>
       <Modal.Content maxWidth={96}>
         <Modal.Header>
           <Text>{props.title}</Text>
@@ -167,7 +142,10 @@ function FilenameModal<
                     message={action.message}
                   />
                 ))}
-                <ModalButton onPress={onDismiss} message={cancel.message} />
+                <ModalButton
+                  onPress={props.onDismiss}
+                  message={cancel.message}
+                />
               </HStack>
             </Center>
           </VStack>

--- a/bulgur-cloud-frontend/src/storage/FolderList.tsx
+++ b/bulgur-cloud-frontend/src/storage/FolderList.tsx
@@ -5,7 +5,7 @@ import { BError } from "../error";
 import { joinURL } from "../fetch";
 import { Loading } from "../Loading";
 import { DashboardParams } from "../routes";
-import { CreateNewDirectory, MoveItems, UploadButton } from "../Upload";
+import { CreateNewFolder, MoveItems, UploadButton } from "../Upload";
 import { FolderListEntry } from "./FolderListEntry";
 
 function ErrorDisplay({ error }: { error: unknown }) {
@@ -84,7 +84,7 @@ export function FABs(params: DashboardParams) {
   return (
     <View height={32}>
       <UploadButton {...params} />
-      <CreateNewDirectory {...params} />
+      <CreateNewFolder {...params} />
       <MoveItems {...params} />
     </View>
   );

--- a/bulgur-cloud-frontend/src/storage/FolderListEntry.tsx
+++ b/bulgur-cloud-frontend/src/storage/FolderListEntry.tsx
@@ -1,12 +1,14 @@
 import { HStack, Icon, Spacer, Text } from "native-base";
-import { useState } from "react";
 import { joinURL } from "../fetch";
 import { FillSpacer } from "../FillSpacer";
-import { storageSlice, useAppDispatch, useAppSelector } from "../store";
-import { DeleteConfirmModal } from "./DeleteConfirmModal";
+import {
+  StorageAction,
+  storageSlice,
+  useAppDispatch,
+  useAppSelector,
+} from "../store";
 import { IMAGE_EXTENSIONS, PDF_EXTENSIONS } from "./File";
 import { FontAwesome5 } from "@expo/vector-icons";
-import { useRenameModal } from "./RenameModal";
 import api from "../api";
 import { DashboardParams } from "../routes";
 import { BLink } from "../BLink";
@@ -46,17 +48,6 @@ export function FolderListEntry(
 
   const { store, path } = route.params;
 
-  // TODO: These modals get rendered for each item, which is expensive.
-  // They should be rendered once, and access some sort of shared state.
-  // Probably use redux.
-  const [isDeleteModalOpen, setDeleteModelOpen] = useState<boolean>(false);
-
-  const [openRenameModal, RenameModal] = useRenameModal({
-    ...params,
-    itemName: item.name,
-    isFile: item.is_file,
-  });
-
   return (
     <HStack space={4} key={item.name} alignItems="center">
       <Icon
@@ -88,7 +79,15 @@ export function FolderListEntry(
         height="100%"
         size={4}
         onPress={() => {
-          openRenameModal();
+          dispatch(
+            storageSlice.actions.promptAction({
+              type: StorageAction.Rename,
+              name: item.name,
+              path,
+              store,
+              isFile: item.is_file,
+            }),
+          );
         }}
       />
       <Spacer flexGrow={0} />
@@ -119,19 +118,17 @@ export function FolderListEntry(
         height="100%"
         size={4}
         onPress={() => {
-          setDeleteModelOpen(true);
+          dispatch(
+            storageSlice.actions.promptAction({
+              type: StorageAction.Delete,
+              name: item.name,
+              store,
+              path,
+              isFile: item.is_file,
+            }),
+          );
         }}
       />
-      {RenameModal}
-      {
-        <DeleteConfirmModal
-          itemName={item.name}
-          isFile={item.is_file}
-          isOpen={isDeleteModalOpen}
-          onClose={() => setDeleteModelOpen(false)}
-          {...params}
-        />
-      }
     </HStack>
   );
 }

--- a/bulgur-cloud-frontend/src/store.ts
+++ b/bulgur-cloud-frontend/src/store.ts
@@ -49,6 +49,12 @@ export const authSlice = createSlice({
   },
 });
 
+export enum StorageAction {
+  Rename = "Rename",
+  Delete = "Delete",
+  CreateFolder = "Create Folder",
+}
+
 export type StorageState = {
   /** Maps item names to full paths, for items that have been marked to be moved. */
   markedForMove: {
@@ -66,11 +72,19 @@ export type StorageState = {
       done: number;
     };
   };
+  action?: {
+    type: StorageAction;
+    isFile: boolean;
+    name: string;
+    store: string;
+    path: string;
+  };
 };
 
 const initialStorageState: StorageState = {
   markedForMove: {},
   uploadProgress: {},
+  action: undefined,
 };
 
 export type LoadFolderPayload = api.FolderResults;
@@ -117,6 +131,14 @@ export const storageSlice = createSlice({
         delete state.uploadProgress[name];
       }
     },
+    promptAction: (state, action: { payload: Required<StorageState>["action"] }) => {
+      state.action = {
+        ...action.payload
+      };
+    },
+    dismissPrompt: (state) => {
+      state.action = undefined;
+    }
   },
 });
 


### PR DESCRIPTION
Previously, Bulgur Cloud would add inactive modal elements for buttons like rename or delete attached to each folder list entry.

Turns out these modals, even if inactive, cost a lot whenever the folder listings need to re-render. So Bulgur Cloud instead uses single, separate modal components that communicate with the buttons on the folder listings using redux.